### PR TITLE
V1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "sideko_rest_api"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c916bc32cad706bf65497bab3d9d8bc39ba6edfcd0bfb0df74f6cf25c641e158"
+checksum = "d4bcbb9198f19a037f2d43d1e24f84edf084732cece919eb5f5ec36414553ed0"
 dependencies = [
  "bytes",
  "http 1.2.0",

--- a/release.py
+++ b/release.py
@@ -192,14 +192,15 @@ def main():
     )
     parser.add_argument(
         "--version",
+        required=True,
         help="Version to release (if not provided, will use current version)",
     )
     args = parser.parse_args()
 
-    current_version = get_current_version()
-    if not args.version:
-        raise Exception(f"Must specify version. Current is: {current_version}")
+    # Confirm `gh` CLI is installed & authenticated
+    run_command("gh auth status", check=True)
 
+    current_version = get_current_version()
     version = args.version
     print(f"\nBumping version from {current_version} to {version}")
 

--- a/sideko/Cargo.toml
+++ b/sideko/Cargo.toml
@@ -32,7 +32,7 @@ tar = "0.4.40"
 tokio = { version = "1.35.1", features = ["time"] }
 url = "2.4.1"
 semver = "1.0.23"
-sideko_rest_api = "0.5.1"
+sideko_rest_api = "0.5.2"
 tempfile = "3.12.0"
 dotenvy = "0.15.7"
 tabled = "0.18.0"

--- a/sideko/src/cmds/api/create.rs
+++ b/sideko/src/cmds/api/create.rs
@@ -27,6 +27,13 @@ pub struct ApiCreateCommand {
     )]
     pub spec: Utf8PathBuf,
 
+    /// Allow linting errors to be present in the provided spec [default: false]
+    ///
+    /// By default creating a new version an OpenAPI that contains linting errors is disallowed.
+    /// If you wish to allow linting errors you may experience issues later with SDK generation or mock servers.
+    #[arg(long)]
+    pub allow_lint_errors: bool,
+
     /// disable mock server for initial version [default: enabled]
     #[arg(long)]
     pub disable_mock: bool,
@@ -50,6 +57,7 @@ impl ApiCreateCommand {
                     )
                 })?,
                 version: VersionOrBump::Str(self.version.clone()),
+                allow_lint_errors: Some(self.allow_lint_errors),
                 ..Default::default()
             })
             .await?;

--- a/sideko/src/cmds/api/create.rs
+++ b/sideko/src/cmds/api/create.rs
@@ -29,7 +29,7 @@ pub struct ApiCreateCommand {
 
     /// Allow linting errors to be present in the provided spec [default: false]
     ///
-    /// By default creating a new version an OpenAPI that contains linting errors is disallowed.
+    /// By default using an OpenAPI that contains linting errors is disallowed.
     /// If you wish to allow linting errors you may experience issues later with SDK generation or mock servers.
     #[arg(long)]
     pub allow_lint_errors: bool,

--- a/sideko/src/cmds/api/version/create.rs
+++ b/sideko/src/cmds/api/version/create.rs
@@ -29,7 +29,7 @@ pub struct ApiVersionCreateCommand {
 
     /// Allow linting errors to be present in the provided spec [default: false]
     ///
-    /// By default creating a new version an OpenAPI that contains linting errors is disallowed.
+    /// By default creating a new version with an OpenAPI that contains linting errors is disallowed.
     /// If you wish to allow linting errors you may experience issues later with SDK generation or mock servers.
     #[arg(long)]
     pub allow_lint_errors: bool,

--- a/sideko/src/cmds/api/version/create.rs
+++ b/sideko/src/cmds/api/version/create.rs
@@ -27,6 +27,13 @@ pub struct ApiVersionCreateCommand {
     )]
     pub spec: Utf8PathBuf,
 
+    /// Allow linting errors to be present in the provided spec [default: false]
+    ///
+    /// By default creating a new version an OpenAPI that contains linting errors is disallowed.
+    /// If you wish to allow linting errors you may experience issues later with SDK generation or mock servers.
+    #[arg(long)]
+    pub allow_lint_errors: bool,
+
     /// disable mock server for new version [default: enabled]
     #[arg(long)]
     pub disable_mock: bool,
@@ -52,6 +59,7 @@ impl ApiVersionCreateCommand {
                     )
                 })?,
                 notes: None,
+                allow_lint_errors: Some(self.allow_lint_errors),
             })
             .await?;
 

--- a/sideko/src/cmds/api/version/update.rs
+++ b/sideko/src/cmds/api/version/update.rs
@@ -31,6 +31,13 @@ pub struct ApiVersionUpdateCommand {
     )]
     pub spec: Option<Utf8PathBuf>,
 
+    /// Allow linting errors to be present in the provided spec [default: false]
+    ///
+    /// By default creating a new version an OpenAPI that contains linting errors is disallowed.
+    /// If you wish to allow linting errors you may experience issues later with SDK generation or mock servers.
+    #[arg(long)]
+    pub allow_lint_errors: bool,
+
     /// enable or disable the mock server
     #[arg(long)]
     pub mock: Option<bool>,
@@ -59,6 +66,7 @@ impl ApiVersionUpdateCommand {
                 version: self.new_version.clone(),
                 mock_server_enabled: self.mock,
                 openapi,
+                allow_lint_errors: Some(self.allow_lint_errors),
                 ..Default::default()
             })
             .await?;

--- a/sideko/src/cmds/api/version/update.rs
+++ b/sideko/src/cmds/api/version/update.rs
@@ -33,7 +33,7 @@ pub struct ApiVersionUpdateCommand {
 
     /// Allow linting errors to be present in the provided spec [default: false]
     ///
-    /// By default creating a new version an OpenAPI that contains linting errors is disallowed.
+    /// By default using an OpenAPI that contains linting errors is disallowed.
     /// If you wish to allow linting errors you may experience issues later with SDK generation or mock servers.
     #[arg(long)]
     pub allow_lint_errors: bool,

--- a/sideko/src/cmds/sdk/init.rs
+++ b/sideko/src/cmds/sdk/init.rs
@@ -68,6 +68,7 @@ impl SdkInitCommand {
                 })?,
                 version: VersionOrBump::Str(version),
                 mock_server_enabled: Some(true),
+                allow_lint_errors: Some(false),
                 ..Default::default()
             })
             .await?;


### PR DESCRIPTION
- `--allow-lint-errors` flag for following commands:
    - `api create`
    - `api version create`
    - `api version update`
- `--errors` filter on `api lint` command